### PR TITLE
Stop overriding CMake's release compile flags.

### DIFF
--- a/Library/Homebrew/formula.rb
+++ b/Library/Homebrew/formula.rb
@@ -1461,8 +1461,6 @@ class Formula
   sig { returns(T::Array[String]) }
   def std_cmake_args
     args = %W[
-      -DCMAKE_C_FLAGS_RELEASE=-DNDEBUG
-      -DCMAKE_CXX_FLAGS_RELEASE=-DNDEBUG
       -DCMAKE_INSTALL_PREFIX=#{prefix}
       -DCMAKE_INSTALL_LIBDIR=lib
       -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
These flags include basic compiler optimization flags without which software can get built completely unoptimized.

While the shims appear to add their own optimization flag on macOS (at least, based on my ARM testing), they do not in the default Linux build which results in CMake packages like LLVM being built without optimizations. This both results in a very large bottle and exceedingly bad performance.

This seems like the best fix to me, as the shims already seem to have the necessary logic to *re-map* optimization flag levels to what Homebrew prefers for platforms like macOS, and so leaving CMake alone to just do its thing seems like the cleanest solution. But I'm open to other suggested fixes if needed.

I will note that without this, LLVM and any other CMake-built software on Linux is ... mostly unusable for me.

-----
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?
-----
